### PR TITLE
add debugfs support,somebody need it

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -615,6 +615,17 @@ mount_part()
             msg "skip"
         fi
     ;;
+    debugfs)
+        msg -n "/debugfs ... "
+        local target="${CHROOT_DIR}/sys/kernel/debug"
+        if ! is_mounted "${target}" ; then
+            [ -d "${target}" ] || mkdir -p "${target}"
+            mount -t debugfs none "${target}"
+            is_ok "fail" "done"
+        else
+            msg "skip"
+        fi
+    ;;
     dev)
         msg -n "/dev ... "
         local target="${CHROOT_DIR}/dev"
@@ -698,7 +709,7 @@ container_mount()
     [ "${METHOD}" = "chroot" ] || return 0
 
     if [ $# -eq 0 ]; then
-        container_mount root proc sys dev shm pts fd tty tun binfmt_misc
+        container_mount root proc sys debugfs dev shm pts fd tty tun binfmt_misc
         return $?
     fi
 


### PR DESCRIPTION
I install linux deploy on my nexus 5, and install ubuntu on it. I find a way to run command which use bionic 
in ubuntu bash by do these step:
1.  mount system and data partion, just like this:  
     /system:/system
     /data:/data
2. use  prefix environment variable to run:
  PATH=/system/bin:$PATH ANDROID_DATA=/data ANDROID_ROOT=/system am
every thing is ok, but i find am will access "/sys/kernel/debug/tracing/trace_marker" internal, so, i add debugfs support , maybe somebody need it