### PR TITLE
Add zstd to base_packages for Arch Linux ARM

### DIFF
--- a/include/bootstrap/archlinux/deploy.sh
+++ b/include/bootstrap/archlinux/deploy.sh
@@ -55,7 +55,7 @@ do_install()
 
     msg ":: Installing ${COMPONENT} ... "
 
-    local base_packages="filesystem acl archlinux-keyring attr bash bzip2 ca-certificates ca-certificates-mozilla ca-certificates-utils coreutils cracklib curl db e2fsprogs expat findutils gcc-libs gdbm glib2 glibc gmp gnupg gnutls gpgme iana-etc keyutils krb5 libarchive libassuan libcap libffi libgcrypt libgpg-error libidn libidn2 libksba libldap libnghttp2 libpsl libsasl libsecret libssh2 libsystemd libtasn1 libtirpc libunistring libutil-linux linux-api-headers lz4 ncurses nettle npth openssl p11-kit pacman pacman-mirrorlist pam pambase pcre perl pinentry readline shadow sqlite sudo tzdata util-linux which xz zlib"
+    local base_packages="filesystem acl archlinux-keyring attr bash bzip2 ca-certificates ca-certificates-mozilla ca-certificates-utils coreutils cracklib curl db e2fsprogs expat findutils gcc-libs gdbm glib2 glibc gmp gnupg gnutls gpgme iana-etc keyutils krb5 libarchive libassuan libcap libffi libgcrypt libgpg-error libidn libidn2 libksba libldap libnghttp2 libpsl libsasl libsecret libssh2 libsystemd libtasn1 libtirpc libunistring libutil-linux linux-api-headers lz4 ncurses nettle npth openssl p11-kit pacman pacman-mirrorlist pam pambase pcre perl pinentry readline shadow sqlite sudo tzdata util-linux which xz zlib zstd"
 
     case "$(get_platform ${ARCH})" in
     x86_64) local repo_url="${SOURCE_PATH%/}/core/os/${ARCH}" ;;


### PR DESCRIPTION
At least on ARMv7H version of Arch Linux ARM pacman depends on libarchive, and libarchive depends on zstd now. So just after the installation the system is pretty useless, because pacman won't run without this lib.
See https://archlinuxarm.org/packages/armv7h/pacman and https://archlinuxarm.org/packages/armv7h/libarchive.