### PR TITLE
Fix ArchLinux installation with Xfce4

### DIFF
--- a/include/desktop/dbus/deploy.sh
+++ b/include/desktop/dbus/deploy.sh
@@ -36,6 +36,18 @@ do_configure()
     make_dirs /run/dbus /var/run/dbus
     chmod 644 "${CHROOT_DIR}/etc/machine-id"
     chroot_exec -u root dbus-uuidgen > "${CHROOT_DIR}/etc/machine-id"
+    case "${DISTRIB}:${ARCH}:${SUITE}" in
+    archlinux:*)
+        chroot_exec -u root groupadd -f network
+
+        local user_names="systemd-timesync systemd-network colord systemd-resolve polkitd avahi dbus"
+        for username in ${user_names}
+        do
+            chroot_exec -u root groupadd -f ${username}
+            chroot_exec -u root useradd -g ${username} -s /bin/false ${username}
+        done
+    ;;
+    esac
     return 0
 }
 

--- a/include/desktop/xfce/deploy.sh
+++ b/include/desktop/xfce/deploy.sh
@@ -30,6 +30,12 @@ do_configure()
 {
     msg ":: Configuring ${COMPONENT} ... "
     local xsession="${CHROOT_DIR}$(user_home ${USER_NAME})/.xsession"
-    echo 'exec dbus-run-session xfce4-session' > "${xsession}"
+    local command='exec dbus-run-session xfce4-session'
+    case "${DISTRIB}:${ARCH}:${SUITE}" in
+    archlinux:*)
+        command='exec dbus-launch xfce4-session'
+    ;;
+    esac
+    echo ${command} > "${xsession}"
     return 0
 }


### PR DESCRIPTION
During install of dbus in ArchLinux there are missing 'network'
group and some service-related users which are needed for correct
start up of dbus. These users have been added manually via
deployment script.
Also command to run Xfce4 is different. For this distribution
it has been changed to 'dbus-launch xfce4-session' instead of
'dbus-run-session xfce4-session'.