### PR TITLE
component for custom power trigger

### DIFF
--- a/include/core/power/deploy.conf
+++ b/include/core/power/deploy.conf
@@ -1,0 +1,5 @@
+# Linux Deploy Component
+# (c) Anton Skshidlevsky <meefik@gmail.com>, GPLv3
+
+NAME="power"
+DESC="Power mangaement"

--- a/include/core/power/deploy.sh
+++ b/include/core/power/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Linux Deploy Component
+# (c) Anton Skshidlevsky <meefik@gmail.com>, GPLv3
+
+do_start()
+{
+    if [ -n "${POWER_TRIGGER}" ]; then
+        msg ":: Starting ${COMPONENT} ... "
+        chroot_exec -u root "${POWER_TRIGGER} start"
+    fi
+    return 0
+}
+
+do_stop()
+{
+    if [ -n "${POWER_TRIGGER}" ]; then
+        msg ":: Stopping ${COMPONENT} ... "
+        chroot_exec -u root "${POWER_TRIGGER} stop"
+    fi
+    return 0
+}
+
+do_help()
+{
+cat <<EOF
+   --power-trigger="${POWER_TRIGGER}"
+     Path to a script inside the container to process power changes.
+
+EOF
+}


### PR DESCRIPTION
This paves the way for a custom script to be run on power change events. The other half of this is a PR to meefik/linuxdeploy which exposes the custom script as an Android app preference.

This can be used, for example, to re-disable `power_save` settings on the wlan0 interface when power state changes. See https://github.com/meefik/linuxdeploy/issues/1092 for background.